### PR TITLE
Make liquibaseorausertable compatible with Liquibase 4.23.0+ (closes #4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>org.liquibase</groupId>
       <artifactId>liquibase-core</artifactId>
-      <version>4.4.3</version>
+      <version>4.25.0</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Update the customer classes not match the newest code of liquibase.

I also changed the implementation of the `support` methods to enable liquibaseorausertable only for oracle database which allows other databases to be used (e.g. for unit tests).